### PR TITLE
Exclude specific app child components from merge

### DIFF
--- a/src/assemblies/dgt.solutions.Plugins/Helper/ComponentMover.cs
+++ b/src/assemblies/dgt.solutions.Plugins/Helper/ComponentMover.cs
@@ -22,6 +22,12 @@ namespace dgt.solutions.Plugins.Helper
         {
             return MoveComponents(GetSolutionComponents(new List<ConditionExpression>{
                 new ConditionExpression(SolutionComponent.LogicalNames.SolutionId, ConditionOperator.Equal, originId)
+
+                // Ignore appelement components (modern buttons) - they should not need to be moved individually and may cause timeouts
+                new ConditionExpression(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.NotEqual, 10053),
+
+                // Ignore appsettings components - they behave weird and add a lot of stuff
+                new ConditionExpression(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.NotEqual, 10056),
             }), destinationName);
         }
 

--- a/src/assemblies/dgt.solutions.Plugins/Helper/ComponentMover.cs
+++ b/src/assemblies/dgt.solutions.Plugins/Helper/ComponentMover.cs
@@ -21,13 +21,12 @@ namespace dgt.solutions.Plugins.Helper
         internal IEnumerable<ComponentMoverLogEntry> MoveComponents(Guid originId, string destinationName)
         {
             return MoveComponents(GetSolutionComponents(new List<ConditionExpression>{
-                new ConditionExpression(SolutionComponent.LogicalNames.SolutionId, ConditionOperator.Equal, originId)
+                new ConditionExpression(SolutionComponent.LogicalNames.SolutionId, ConditionOperator.Equal, originId),
 
-                // Ignore appelement components (modern buttons) - they should not need to be moved individually and may cause timeouts
-                new ConditionExpression(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.NotEqual, 10053),
-
-                // Ignore appsettings components - they behave weird and add a lot of stuff
-                new ConditionExpression(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.NotEqual, 10056),
+                // Ignore app child elements - there should be no need to move them independently
+                new ConditionExpression(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.NotEqual, 10053 /* appelement */),
+                new ConditionExpression(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.NotEqual, 10056 /* appsetting */),
+                new ConditionExpression(SolutionComponent.LogicalNames.ComponentType, ConditionOperator.NotEqual, 10160 /* appaction */),
             }), destinationName);
         }
 


### PR DESCRIPTION
This will exlude the solutioncomponents of type `appelement` and `appsetting` to be merged.

We encountered an issue on merging a workbench that contained an app and hidden solutioncomponents of those types to have weird behaviours:
- Moving all the appelements ran us in timeouts
- Moving the appsettings included a lot of tables that should not have been moved

We used this fix as a bandaid to fix those issues in the short term, please review and merge or reject if you think that is an applicaple solution.

In my opinion both of these elements only ever are allowed to exist within an app, so there should be no reason to ever move them without the app itself, so should have no effect excluding them from moving.